### PR TITLE
feat(cli): add basic CLI app scaffold

### DIFF
--- a/apps/cli/eslint.config.mjs
+++ b/apps/cli/eslint.config.mjs
@@ -1,0 +1,4 @@
+import { config } from "@roo-code/config-eslint/base"
+
+/** @type {import("eslint").Linter.Config} */
+export default [...config]

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,0 +1,28 @@
+{
+	"name": "@roo-code/cli",
+	"version": "0.0.0",
+	"private": true,
+	"type": "module",
+	"bin": {
+		"kilo": "./dist/index.js"
+	},
+	"scripts": {
+		"build": "tsc -p tsconfig.json",
+		"start": "node ./dist/index.js",
+		"lint": "eslint src --ext=ts --max-warnings=0",
+		"check-types": "tsc --noEmit",
+		"clean": "rimraf dist .turbo"
+	},
+	"dependencies": {
+		"@dotenvx/dotenvx": "^1.34.0",
+		"@roo-code/telemetry": "workspace:^",
+		"@roo-code/types": "workspace:^"
+	},
+	"devDependencies": {
+		"@roo-code/config-eslint": "workspace:^",
+		"@roo-code/config-typescript": "workspace:^",
+		"@types/node": "20.x",
+		"@types/vscode": "^1.84.0",
+		"typescript": "^5.4.5"
+	}
+}

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -1,0 +1,78 @@
+import * as readline from "readline"
+import * as dotenvx from "@dotenvx/dotenvx"
+import * as path from "path"
+
+import { TelemetryService, PostHogTelemetryClient } from "@roo-code/telemetry"
+import { ContextProxy } from "../../src/core/config/ContextProxy.ts"
+
+class Agent {
+	async handlePrompt(prompt: string): Promise<string> {
+		// Placeholder for real agent dispatch
+		return `Echo: ${prompt}`
+	}
+}
+
+async function main() {
+	// Load environment variables from .env file
+	try {
+		const envPath = path.join(__dirname, "..", ".env")
+		dotenvx.config({ path: envPath })
+	} catch (e) {
+		console.warn("Failed to load environment variables:", e)
+	}
+
+	// Minimal stub for VS Code ExtensionContext
+	const extensionContext: any = {
+		globalState: {
+			get: () => undefined,
+			update: async () => undefined,
+		},
+		secrets: {
+			get: async () => undefined,
+			store: async () => undefined,
+			delete: async () => undefined,
+		},
+		subscriptions: [],
+		extensionPath: process.cwd(),
+		extensionUri: { fsPath: process.cwd() },
+		globalStorageUri: { fsPath: path.join(process.cwd(), ".roo") },
+		logUri: { fsPath: path.join(process.cwd(), ".roo", "log") },
+	}
+
+	await ContextProxy.getInstance(extensionContext)
+
+	const telemetry = TelemetryService.createInstance()
+	try {
+		telemetry.register(new PostHogTelemetryClient())
+	} catch (error) {
+		console.warn("Failed to register Telemetry client:", error)
+	}
+
+	const agent = new Agent()
+
+	const rl = readline.createInterface({
+		input: process.stdin,
+		output: process.stdout,
+	})
+
+	const promptLoop = () => {
+		rl.question("> ", async (input) => {
+			if (input.trim().toLowerCase() === "exit") {
+				rl.close()
+				return
+			}
+
+			const response = await agent.handlePrompt(input)
+			console.log(response)
+			promptLoop()
+		})
+	}
+
+	rl.on("close", () => process.exit(0))
+	promptLoop()
+}
+
+main().catch((err) => {
+	console.error(err)
+	process.exit(1)
+})

--- a/apps/cli/tsconfig.json
+++ b/apps/cli/tsconfig.json
@@ -1,0 +1,15 @@
+{
+	"extends": "@roo-code/config-typescript/base.json",
+	"compilerOptions": {
+		"outDir": "dist",
+		"rootDir": "src",
+		"baseUrl": "./",
+		"allowImportingTsExtensions": true,
+		"paths": {
+			"@roo-code/telemetry": ["../../packages/telemetry/src/index.ts"],
+			"@roo-code/types": ["../../packages/types/src/index.ts"]
+		}
+	},
+	"include": ["src"],
+	"exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- add new `@roo-code/cli` app with bin `kilo`
- bootstrap agent environment and telemetry in CLI entrypoint
- simple REPL that echoes prompts (placeholder for full agent dispatch)

## Testing
- `pnpm install --filter @roo-code/cli` *(fails: ERR_PNPM_FETCH_403 Forbidden)*
- `pnpm --filter @roo-code/cli check-types` *(fails: Cannot find module '@roo-code/telemetry')*
- `pnpm --filter @roo-code/cli lint` *(fails: Cannot find package '@roo-code/config-eslint')*


------
https://chatgpt.com/codex/tasks/task_e_68c5fa1b7534832290ff0737f0c4349f