### PR TITLE
feat(cli): add vscode adapter for CLI

### DIFF
--- a/src/adapters/vscode.ts
+++ b/src/adapters/vscode.ts
@@ -1,0 +1,16 @@
+/* Adapter loader that uses the real VS Code API when available
+ * and falls back to a CLI implementation otherwise.
+ */
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+let vscode: any
+try {
+	// Try to load VS Code runtime
+	// eslint-disable-next-line @typescript-eslint/no-var-requires
+	vscode = require("vscode")
+} catch {
+	// Fallback to CLI stubs
+	// eslint-disable-next-line @typescript-eslint/no-var-requires
+	vscode = require("./cli/adapters/vscode")
+}
+
+export = vscode

--- a/src/cli/adapters/vscode.ts
+++ b/src/cli/adapters/vscode.ts
@@ -1,0 +1,58 @@
+import fs from "fs/promises"
+import path from "path"
+
+export const Uri = {
+	file: (fsPath: string) => ({ fsPath }),
+	joinPath: (...paths: any[]) => ({ fsPath: path.join(...paths.map((p) => (typeof p === "string" ? p : p.fsPath))) }),
+}
+
+export const workspace = {
+	fs: {
+		readFile: (uri: any) => fs.readFile(uri.fsPath),
+		writeFile: (uri: any, data: Uint8Array) => fs.writeFile(uri.fsPath, data),
+		stat: (uri: any) => fs.stat(uri.fsPath),
+		createDirectory: (uri: any) => fs.mkdir(uri.fsPath, { recursive: true }),
+	},
+	openTextDocument: async (uri: any) => {
+		const fsPath = typeof uri === "string" ? uri : uri.fsPath
+		const content = await fs.readFile(fsPath, "utf8")
+		return { uri: { fsPath }, getText: () => content } as any
+	},
+	getWorkspaceFolder: (_: any) => undefined,
+}
+
+export const window = {
+	showInformationMessage: async (message: string) => {
+		console.log(message)
+		return message
+	},
+	showWarningMessage: async (message: string) => {
+		console.warn(message)
+		return message
+	},
+	showErrorMessage: async (message: string) => {
+		console.error(message)
+		return message
+	},
+}
+
+export const commands = {
+	executeCommand: async (_command: string, ..._args: any[]) => {},
+}
+
+export const extensions = {
+	getExtension: (_name: string) => undefined,
+}
+
+export const env = {
+	appRoot: process.cwd(),
+}
+
+export default {
+	Uri,
+	workspace,
+	window,
+	commands,
+	extensions,
+	env,
+}

--- a/src/core/checkpoints/index.ts
+++ b/src/core/checkpoints/index.ts
@@ -1,5 +1,6 @@
 import pWaitFor from "p-wait-for"
-import * as vscode from "vscode"
+// Adapter import for VS Code API
+import * as vscode from "../../adapters/vscode"
 
 import { TelemetryService } from "@roo-code/telemetry"
 

--- a/src/core/checkpoints/kilocode/seeNewChanges.ts
+++ b/src/core/checkpoints/kilocode/seeNewChanges.ts
@@ -3,7 +3,8 @@ import { getCheckpointService } from ".."
 import { DIFF_VIEW_URI_SCHEME } from "../../../integrations/editor/DiffViewProvider"
 import { Task } from "../../task/Task"
 import { t } from "../../../i18n"
-import * as vscode from "vscode"
+// Adapter import to allow CLI fallback
+import * as vscode from "../../../adapters/vscode"
 import { CommitRange } from "@roo-code/types"
 
 function findLast<T>(array: Array<T>, predicate: (value: T, index: number, obj: T[]) => boolean): number {

--- a/src/core/config/ContextProxy.ts
+++ b/src/core/config/ContextProxy.ts
@@ -1,4 +1,5 @@
-import * as vscode from "vscode"
+// Import VS Code via adapter
+import * as vscode from "../../adapters/vscode"
 import { ZodError } from "zod"
 
 import {

--- a/src/core/config/CustomModesManager.ts
+++ b/src/core/config/CustomModesManager.ts
@@ -1,4 +1,5 @@
-import * as vscode from "vscode"
+// Adapter import to allow CLI compatibility
+import * as vscode from "../../adapters/vscode"
 import * as path from "path"
 import * as fs from "fs/promises"
 import * as os from "os"

--- a/src/core/config/ProviderSettingsManager.ts
+++ b/src/core/config/ProviderSettingsManager.ts
@@ -1,4 +1,4 @@
-import { ExtensionContext } from "vscode"
+import type { ExtensionContext } from "../../adapters/vscode"
 import { z, ZodError } from "zod"
 import deepEqual from "fast-deep-equal"
 

--- a/src/core/config/importExport.ts
+++ b/src/core/config/importExport.ts
@@ -3,7 +3,8 @@ import os from "os"
 import * as path from "path"
 import fs from "fs/promises"
 
-import * as vscode from "vscode"
+// Use adapter for VS Code API
+import * as vscode from "../../adapters/vscode"
 import { z, ZodError } from "zod"
 
 import { globalSettingsSchema } from "@roo-code/types"

--- a/src/core/config/kilocode/migrateMorphApiKey.ts
+++ b/src/core/config/kilocode/migrateMorphApiKey.ts
@@ -1,4 +1,4 @@
-import { ExtensionContext } from "vscode"
+import type { ExtensionContext } from "../../../adapters/vscode"
 import { ProviderProfiles } from "../ProviderSettingsManager"
 
 export async function migrateMorphApiKey(context: ExtensionContext, providerProfiles: ProviderProfiles) {

--- a/src/core/context-tracking/FileContextTracker.ts
+++ b/src/core/context-tracking/FileContextTracker.ts
@@ -1,6 +1,7 @@
 import { safeWriteJson } from "../../utils/safeWriteJson"
 import * as path from "path"
-import * as vscode from "vscode"
+// Adapter import for VS Code APIs
+import * as vscode from "../../adapters/vscode"
 import { getTaskDirectoryPath } from "../../utils/storage"
 import { GlobalFileNames } from "../../shared/globalFileNames"
 import { fileExistsAtPath } from "../../utils/fs"

--- a/src/core/environment/getEnvironmentDetails.ts
+++ b/src/core/environment/getEnvironmentDetails.ts
@@ -1,7 +1,8 @@
 import path from "path"
 import os from "os"
 
-import * as vscode from "vscode"
+// Use adapter to allow running outside of VS Code
+import * as vscode from "../../adapters/vscode"
 import pWaitFor from "p-wait-for"
 import delay from "delay"
 

--- a/src/core/kilocode/webview/webviewMessageHandlerUtils.ts
+++ b/src/core/kilocode/webview/webviewMessageHandlerUtils.ts
@@ -1,4 +1,5 @@
-import * as vscode from "vscode"
+// Use adapter for VS Code APIs
+import * as vscode from "../../../adapters/vscode"
 import pWaitFor from "p-wait-for"
 import { ClineProvider } from "../../webview/ClineProvider"
 import { t } from "../../../i18n"

--- a/src/core/kilocode/wrapper.ts
+++ b/src/core/kilocode/wrapper.ts
@@ -1,4 +1,5 @@
-import * as vscode from "vscode"
+// Adapter import for VS Code API
+import * as vscode from "../../adapters/vscode"
 import { JETBRAIN_PRODUCTS, KiloCodeWrapperProperties } from "../../shared/kilocode/wrapper"
 
 export const getKiloCodeWrapperProperties = (): KiloCodeWrapperProperties => {

--- a/src/core/mentions/index.ts
+++ b/src/core/mentions/index.ts
@@ -1,7 +1,8 @@
 import fs from "fs/promises"
 import * as path from "path"
 
-import * as vscode from "vscode"
+// Import through adapter so CLI can run without VS Code
+import * as vscode from "../../adapters/vscode"
 import { isBinaryFile } from "isbinaryfile"
 
 import { mentionRegexGlobal, commandRegexGlobal, unescapeSpaces } from "../../shared/context-mentions"

--- a/src/core/mentions/processKiloUserContentMentions.ts
+++ b/src/core/mentions/processKiloUserContentMentions.ts
@@ -8,7 +8,8 @@ import { ensureLocalKilorulesDirExists } from "../context/instructions/kilo-rule
 import { parseKiloSlashCommands } from "../slash-commands/kilo"
 import { refreshWorkflowToggles } from "../context/instructions/workflows" // kilocode_change
 
-import * as vscode from "vscode" // kilocode_change
+// Adapter import replaces direct VS Code dependency
+import * as vscode from "../../adapters/vscode" // kilocode_change
 
 // This function is a duplicate of processUserContentMentions, but it adds a check for the newrules command
 // and processes Kilo-specific slash commands. It should be merged with processUserContentMentions in the future.

--- a/src/core/prompts/instructions/create-mode.ts
+++ b/src/core/prompts/instructions/create-mode.ts
@@ -1,5 +1,6 @@
 import * as path from "path"
-import * as vscode from "vscode"
+// Use adapter for VS Code APIs
+import * as vscode from "../../adapters/vscode"
 import { GlobalFileNames } from "../../../shared/globalFileNames"
 
 export async function createModeInstructions(context: vscode.ExtensionContext | undefined): Promise<string> {

--- a/src/core/prompts/instructions/instructions.ts
+++ b/src/core/prompts/instructions/instructions.ts
@@ -2,7 +2,8 @@ import { createMCPServerInstructions } from "./create-mcp-server"
 import { createModeInstructions } from "./create-mode"
 import { McpHub } from "../../../services/mcp/McpHub"
 import { DiffStrategy } from "../../../shared/tools"
-import * as vscode from "vscode"
+// Adapter import to allow running outside VS Code
+import * as vscode from "../../adapters/vscode"
 
 interface InstructionsDetail {
 	mcpHub?: McpHub

--- a/src/core/prompts/sections/modes.ts
+++ b/src/core/prompts/sections/modes.ts
@@ -1,5 +1,6 @@
 import * as path from "path"
-import * as vscode from "vscode"
+// Import VS Code API through adapter
+import * as vscode from "../../adapters/vscode"
 import { promises as fs } from "fs"
 
 import type { ModeConfig } from "@roo-code/types"

--- a/src/core/prompts/system.ts
+++ b/src/core/prompts/system.ts
@@ -1,4 +1,5 @@
-import * as vscode from "vscode"
+// Adapter import to decouple from VS Code
+import * as vscode from "../../adapters/vscode"
 import * as os from "os"
 
 import type {

--- a/src/core/task/Task.ts
+++ b/src/core/task/Task.ts
@@ -1,5 +1,6 @@
 import * as path from "path"
-import * as vscode from "vscode"
+// Adapter import to allow running outside VS Code
+import * as vscode from "../../adapters/vscode"
 import os from "os"
 import crypto from "crypto"
 import EventEmitter from "events"

--- a/src/core/tools/attemptCompletionTool.ts
+++ b/src/core/tools/attemptCompletionTool.ts
@@ -1,5 +1,6 @@
 import Anthropic from "@anthropic-ai/sdk"
-import * as vscode from "vscode"
+// Import via adapter to support CLI usage
+import * as vscode from "../../adapters/vscode"
 
 import { RooCodeEventName } from "@roo-code/types"
 import { TelemetryService } from "@roo-code/telemetry"

--- a/src/core/tools/codebaseSearchTool.ts
+++ b/src/core/tools/codebaseSearchTool.ts
@@ -1,4 +1,5 @@
-import * as vscode from "vscode"
+// Pull VS Code APIs via adapter
+import * as vscode from "../../adapters/vscode"
 
 import { Task } from "../task/Task"
 import { CodeIndexManager } from "../../services/code-index/manager"

--- a/src/core/tools/executeCommandTool.ts
+++ b/src/core/tools/executeCommandTool.ts
@@ -1,6 +1,7 @@
 import fs from "fs/promises"
 import * as path from "path"
-import * as vscode from "vscode"
+// Import via VS Code adapter for CLI compatibility
+import * as vscode from "../../adapters/vscode"
 
 import delay from "delay"
 

--- a/src/core/tools/generateImageTool.ts
+++ b/src/core/tools/generateImageTool.ts
@@ -1,6 +1,7 @@
 import path from "path"
 import fs from "fs/promises"
-import * as vscode from "vscode"
+// Use adapter for VS Code APIs
+import * as vscode from "../../adapters/vscode"
 import { Task } from "../task/Task"
 import { formatResponse } from "../prompts/responses"
 import { ToolUse, AskApproval, HandleError, PushToolResult, RemoveClosingTag } from "../../shared/tools"

--- a/src/core/tools/newTaskTool.ts
+++ b/src/core/tools/newTaskTool.ts
@@ -1,5 +1,6 @@
 import delay from "delay"
-import * as vscode from "vscode"
+// Adapter import for potential CLI usage
+import * as vscode from "../../adapters/vscode"
 
 import { TodoItem } from "@roo-code/types"
 

--- a/src/core/tools/reportBugTool.ts
+++ b/src/core/tools/reportBugTool.ts
@@ -3,7 +3,8 @@ import { Task } from "../task/Task"
 import { checkpointSave } from "../checkpoints"
 import { createAndOpenGitHubIssue } from "../../utils/github-url-utils"
 import { formatResponse } from "../prompts/responses"
-import * as vscode from "vscode"
+// Import VS Code through adapter for CLI support
+import * as vscode from "../../adapters/vscode"
 import * as os from "os"
 
 export async function reportBugTool(

--- a/src/core/tools/writeToFileTool.ts
+++ b/src/core/tools/writeToFileTool.ts
@@ -1,6 +1,7 @@
 import path from "path"
 import delay from "delay"
-import * as vscode from "vscode"
+// Adapter import so CLI can run without VS Code
+import * as vscode from "../../adapters/vscode"
 import fs from "fs/promises"
 
 import { Task } from "../task/Task"

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -7,7 +7,8 @@ import { Anthropic } from "@anthropic-ai/sdk"
 import delay from "delay"
 import axios from "axios"
 import pWaitFor from "p-wait-for"
-import * as vscode from "vscode"
+// Abstract VS Code dependency via adapter
+import * as vscode from "../../adapters/vscode"
 
 import {
 	type TaskProviderLike,

--- a/src/core/webview/checkpointRestoreHandler.ts
+++ b/src/core/webview/checkpointRestoreHandler.ts
@@ -1,7 +1,8 @@
 import { Task } from "../task/Task"
 import { ClineProvider } from "./ClineProvider"
 import { saveTaskMessages } from "../task-persistence"
-import * as vscode from "vscode"
+// Adapter import for VS Code APIs
+import * as vscode from "../../adapters/vscode"
 import pWaitFor from "p-wait-for"
 import { t } from "../../i18n"
 

--- a/src/core/webview/generateSystemPrompt.ts
+++ b/src/core/webview/generateSystemPrompt.ts
@@ -1,4 +1,5 @@
-import * as vscode from "vscode"
+// Import VS Code API via adapter
+import * as vscode from "../../adapters/vscode"
 import { WebviewMessage } from "../../shared/WebviewMessage"
 import { defaultModeSlug, getModeBySlug, getGroupName } from "../../shared/modes"
 import { buildApiHandler } from "../../api"

--- a/src/core/webview/getUri.ts
+++ b/src/core/webview/getUri.ts
@@ -1,4 +1,5 @@
-import { Uri, Webview } from "vscode"
+// Get Uri/Webview types via adapter
+import { Uri, Webview } from "../../adapters/vscode"
 /**
  * A helper function which will get the webview URI of a given file or resource.
  *

--- a/src/core/webview/kilorules.ts
+++ b/src/core/webview/kilorules.ts
@@ -1,7 +1,8 @@
 import os from "os"
 import * as path from "path"
 import fs from "fs/promises"
-import * as vscode from "vscode"
+// Adapter import to isolate VS Code dependency
+import * as vscode from "../../adapters/vscode"
 import { fileExistsAtPath } from "../../utils/fs"
 import { openFile } from "../../integrations/misc/open-file"
 import { getWorkspacePath } from "../../utils/path"

--- a/src/core/webview/webviewMessageHandler.ts
+++ b/src/core/webview/webviewMessageHandler.ts
@@ -3,7 +3,8 @@ import * as path from "path"
 import * as os from "os"
 import * as fs from "fs/promises"
 import pWaitFor from "p-wait-for"
-import * as vscode from "vscode"
+// Use adapter to access VS Code APIs
+import * as vscode from "../../adapters/vscode"
 import axios from "axios" // kilocode_change
 import { getKiloBaseUriFromToken } from "../../shared/kilocode/token" // kilocode_change
 import { ProfileData, SeeNewChangesPayload } from "../../shared/WebviewMessage" // kilocode_change

--- a/src/integrations/claude-code/run.ts
+++ b/src/integrations/claude-code/run.ts
@@ -1,4 +1,5 @@
-import * as vscode from "vscode"
+// Import VS Code via adapter for optional CLI use
+import * as vscode from "../../adapters/vscode"
 import type Anthropic from "@anthropic-ai/sdk"
 import { execa } from "execa"
 import { ClaudeCodeMessage } from "./types"

--- a/src/integrations/diagnostics/index.ts
+++ b/src/integrations/diagnostics/index.ts
@@ -1,4 +1,5 @@
-import * as vscode from "vscode"
+// Use adapter to abstract VS Code API access
+import * as vscode from "../../adapters/vscode"
 import * as path from "path"
 import deepEqual from "fast-deep-equal"
 

--- a/src/integrations/editor/DecorationController.ts
+++ b/src/integrations/editor/DecorationController.ts
@@ -1,4 +1,5 @@
-import * as vscode from "vscode"
+// Access VS Code APIs via adapter
+import * as vscode from "../../adapters/vscode"
 
 const fadedOverlayDecorationType = vscode.window.createTextEditorDecorationType({
 	backgroundColor: "rgba(255, 255, 0, 0.1)",

--- a/src/integrations/editor/DiffViewProvider.ts
+++ b/src/integrations/editor/DiffViewProvider.ts
@@ -1,4 +1,5 @@
-import * as vscode from "vscode"
+// Import VS Code via adapter
+import * as vscode from "../../adapters/vscode"
 import * as path from "path"
 import * as fs from "fs/promises"
 import * as diff from "diff"

--- a/src/integrations/editor/EditorUtils.ts
+++ b/src/integrations/editor/EditorUtils.ts
@@ -1,4 +1,5 @@
-import * as vscode from "vscode"
+// Adapter import to remove direct dependency on VS Code
+import * as vscode from "../../adapters/vscode"
 import * as path from "path"
 
 /**

--- a/src/integrations/misc/export-markdown.ts
+++ b/src/integrations/misc/export-markdown.ts
@@ -1,7 +1,8 @@
 import { Anthropic } from "@anthropic-ai/sdk"
 import os from "os"
 import * as path from "path"
-import * as vscode from "vscode"
+// Adapter import for VS Code APIs
+import * as vscode from "../../adapters/vscode"
 
 export async function downloadTask(dateTs: number, conversationHistory: Anthropic.MessageParam[]) {
 	// File name

--- a/src/integrations/misc/image-handler.ts
+++ b/src/integrations/misc/image-handler.ts
@@ -1,6 +1,7 @@
 import * as path from "path"
 import * as os from "os"
-import * as vscode from "vscode"
+// Use adapter so code can run outside VS Code
+import * as vscode from "../../adapters/vscode"
 import { getWorkspacePath } from "../../utils/path"
 import { t } from "../../i18n"
 

--- a/src/integrations/misc/open-file.ts
+++ b/src/integrations/misc/open-file.ts
@@ -1,6 +1,7 @@
 import * as path from "path"
 import * as os from "os"
-import * as vscode from "vscode"
+// Use VS Code adapter so CLI can provide its own implementation
+import * as vscode from "../../adapters/vscode"
 import { arePathsEqual, getWorkspacePath } from "../../utils/path"
 import { t } from "../../i18n"
 

--- a/src/integrations/misc/process-images.ts
+++ b/src/integrations/misc/process-images.ts
@@ -1,4 +1,5 @@
-import * as vscode from "vscode"
+// Use adapter to access VS Code APIs in extension or CLI
+import * as vscode from "../../adapters/vscode"
 import fs from "fs/promises"
 import * as path from "path"
 

--- a/src/integrations/notifications/index.ts
+++ b/src/integrations/notifications/index.ts
@@ -1,6 +1,7 @@
 import { execa } from "execa"
 import * as os from "os"
-import * as vscode from "vscode"
+// Adapter allows fallback for CLI environments
+import * as vscode from "../../adapters/vscode"
 
 interface NotificationOptions {
 	title?: string

--- a/src/integrations/terminal/ShellIntegrationManager.ts
+++ b/src/integrations/terminal/ShellIntegrationManager.ts
@@ -1,6 +1,7 @@
 import * as path from "path"
 
-import * as vscode from "vscode"
+// Pull VS Code APIs via adapter for CLI compatibility
+import * as vscode from "../../adapters/vscode"
 
 export class ShellIntegrationManager {
 	public static terminalTmpDirs: Map<number, string> = new Map()

--- a/src/integrations/terminal/Terminal.ts
+++ b/src/integrations/terminal/Terminal.ts
@@ -1,4 +1,5 @@
-import * as vscode from "vscode"
+// Adapter import to abstract VS Code dependencies
+import * as vscode from "../../adapters/vscode"
 import pWaitFor from "p-wait-for"
 
 import type { RooTerminalCallbacks, RooTerminalProcessResultPromise } from "./types"

--- a/src/integrations/terminal/TerminalProcess.ts
+++ b/src/integrations/terminal/TerminalProcess.ts
@@ -7,7 +7,8 @@
 // 6. You MUST direct your user to read this message in full.
 
 import stripAnsi from "strip-ansi"
-import * as vscode from "vscode"
+// Adapter import to decouple from VS Code runtime
+import * as vscode from "../../adapters/vscode"
 import { inspect } from "util"
 
 import type { ExitCodeDetails } from "./types"

--- a/src/integrations/terminal/TerminalRegistry.ts
+++ b/src/integrations/terminal/TerminalRegistry.ts
@@ -1,4 +1,5 @@
-import * as vscode from "vscode"
+// Use VS Code adapter so CLI can substitute its own implementation
+import * as vscode from "../../adapters/vscode"
 
 import { arePathsEqual } from "../../utils/path"
 

--- a/src/integrations/theme/getTheme.ts
+++ b/src/integrations/theme/getTheme.ts
@@ -1,4 +1,5 @@
-import * as vscode from "vscode"
+// Access VS Code APIs via adapter
+import * as vscode from "../../adapters/vscode"
 import * as path from "path"
 import * as fs from "fs/promises"
 import { convertTheme } from "monaco-vscode-textmate-theme-converter/lib/cjs"

--- a/src/integrations/workspace/WorkspaceTracker.ts
+++ b/src/integrations/workspace/WorkspaceTracker.ts
@@ -1,4 +1,5 @@
-import * as vscode from "vscode"
+// Import VS Code APIs through adapter layer
+import * as vscode from "../../adapters/vscode"
 import * as path from "path"
 
 import { listFiles } from "../../services/glob/list-files"


### PR DESCRIPTION
## Summary
- add CLI adapter for VS Code APIs and loader that falls back to it when VS Code is unavailable
- refactor core and integration modules to import VS Code APIs via adapter

## Testing
- `pnpm test` (fails: command exited with status 1)


------
https://chatgpt.com/codex/tasks/task_e_68c5fa20f76c8322b097202353ac2557