### PR TITLE
feat: support project arg and config loader

### DIFF
--- a/packages/evals/src/cli/index.ts
+++ b/packages/evals/src/cli/index.ts
@@ -18,9 +18,14 @@ const main = async () => {
 				ci: flag({ type: boolean, long: "ci", defaultValue: () => false }),
 				runId: option({ type: number, long: "runId", short: "r", defaultValue: () => -1 }),
 				taskId: option({ type: number, long: "taskId", short: "t", defaultValue: () => -1 }),
+				project: option({ type: String, long: "project", defaultValue: () => "" }),
+				cwd: option({ type: String, long: "cwd", defaultValue: () => "" }),
 			},
 			handler: async (args) => {
-				const { runId, taskId, ci } = args
+				const { runId, taskId, ci, project, cwd } = args
+
+				const workspaceRoot = project || cwd || process.cwd()
+				process.env.KILOCODE_WORKSPACE_ROOT = workspaceRoot
 
 				try {
 					if (ci) {

--- a/packages/evals/src/cli/runTask.ts
+++ b/packages/evals/src/cli/runTask.ts
@@ -14,6 +14,7 @@ import {
 	EVALS_SETTINGS,
 } from "@roo-code/types"
 import { IpcClient } from "@roo-code/ipc"
+import { loadCliConfig } from "../../../../src/cli/config.ts"
 
 import {
 	type Run,
@@ -302,11 +303,15 @@ export const runTask = async ({ run, task, publish, logger }: RunTaskOptions) =>
 		isClientDisconnected = true
 	})
 
+	const workspaceRoot = process.env.KILOCODE_WORKSPACE_ROOT || process.cwd()
+	const cliConfig = await loadCliConfig(workspaceRoot).catch(() => ({}))
+
 	client.sendCommand({
 		commandName: TaskCommandName.StartNewTask,
 		data: {
 			configuration: {
 				...EVALS_SETTINGS,
+				...cliConfig,
 				openRouterApiKey: process.env.OPENROUTER_API_KEY,
 				...run.settings, // Allow the provided settings to override `openRouterApiKey`.
 			},

--- a/src/cli/config.ts
+++ b/src/cli/config.ts
@@ -1,0 +1,81 @@
+import fs from "fs/promises"
+import path from "path"
+import os from "os"
+import YAML from "yaml"
+
+import type { RooCodeSettings } from "@roo-code/types"
+
+async function fileExists(p: string) {
+	try {
+		await fs.access(p)
+		return true
+	} catch {
+		return false
+	}
+}
+
+async function readConfigFile(filePath: string): Promise<any> {
+	const content = await fs.readFile(filePath, "utf-8")
+	if (filePath.endsWith(".json")) {
+		return JSON.parse(content)
+	}
+	return YAML.parse(content)
+}
+
+export async function loadCliConfig(cwd: string): Promise<Partial<RooCodeSettings>> {
+	const configCandidates = [
+		path.join(cwd, ".kilocode", "settings.json"),
+		path.join(cwd, ".kilocode", "settings.yaml"),
+		path.join(cwd, ".kilocode", "settings.yml"),
+		path.join(cwd, "kilocode.json"),
+		path.join(cwd, "kilocode.yaml"),
+		path.join(cwd, "kilocode.yml"),
+	]
+
+	let settings: any = {}
+
+	for (const candidate of configCandidates) {
+		if (await fileExists(candidate)) {
+			settings = await readConfigFile(candidate)
+			break
+		}
+	}
+
+	const homeConfigCandidates = [
+		path.join(os.homedir(), ".kilocode", "config"),
+		path.join(os.homedir(), ".kilocode", "config.json"),
+		path.join(os.homedir(), ".kilocode", "config.yaml"),
+		path.join(os.homedir(), ".kilocode", "config.yml"),
+	]
+
+	let homeConfig: any = {}
+	for (const candidate of homeConfigCandidates) {
+		if (await fileExists(candidate)) {
+			homeConfig = await readConfigFile(candidate)
+			break
+		}
+	}
+
+	const credentialEnvMap: Record<string, string[]> = {
+		openaiApiKey: ["OPENAI_API_KEY"],
+		anthropicApiKey: ["ANTHROPIC_API_KEY"],
+		openRouterApiKey: ["OPENROUTER_API_KEY"],
+		geminiApiKey: ["GEMINI_API_KEY", "GOOGLE_API_KEY"],
+	}
+
+	const credentials: Record<string, string> = {}
+	for (const [key, envVars] of Object.entries(credentialEnvMap)) {
+		for (const envVar of envVars) {
+			const value = process.env[envVar]
+			if (value) {
+				credentials[key] = value
+				break
+			}
+		}
+		if (!credentials[key] && homeConfig[key]) {
+			credentials[key] = homeConfig[key]
+		}
+	}
+
+	return { ...settings, ...credentials }
+}


### PR DESCRIPTION
## Summary
- add configuration loader for CLI that reads workspace settings and credential sources
- allow evals CLI to accept `--project`/`--cwd` and expose workspace root
- pass loaded settings to agent initialization

## Testing
- `pnpm --filter @roo-code/evals test`
- `pnpm --filter @roo-code/evals lint`


------
https://chatgpt.com/codex/tasks/task_e_68c5fa2c24b4832296a9bbb4a088f45e