### PR TITLE
feat: add CLI terminal using child_process

### DIFF
--- a/src/integrations/terminal/CLITerminal.ts
+++ b/src/integrations/terminal/CLITerminal.ts
@@ -1,0 +1,43 @@
+import type { RooTerminalCallbacks, RooTerminalProcessResultPromise } from "./types"
+import { BaseTerminal } from "./BaseTerminal"
+import { CLITerminalProcess } from "./CLITerminalProcess"
+import { mergePromise } from "./mergePromise"
+
+/**
+ * Terminal implementation for CLI usage. It uses Node's child_process APIs to
+ * execute commands without relying on VSCode APIs.
+ */
+export class CLITerminal extends BaseTerminal {
+	constructor(id: number, cwd: string) {
+		super("cli", id, cwd)
+	}
+
+	/**
+	 * CLI terminals never close automatically. They exist for the duration of
+	 * the process.
+	 */
+	public override isClosed(): boolean {
+		return false
+	}
+
+	public override runCommand(command: string, callbacks: RooTerminalCallbacks): RooTerminalProcessResultPromise {
+		this.busy = true
+
+		const process = new CLITerminalProcess(this)
+		process.command = command
+		this.process = process
+
+		process.on("line", (line) => callbacks.onLine(line, process))
+		process.once("completed", (output) => callbacks.onCompleted(output, process))
+		process.once("shell_execution_started", (pid) => callbacks.onShellExecutionStarted(pid, process))
+		process.once("shell_execution_complete", (details) => callbacks.onShellExecutionComplete(details, process))
+
+		const promise = new Promise<void>((resolve, reject) => {
+			process.once("continue", () => resolve())
+			process.once("error", (error) => reject(error))
+			process.run(command)
+		})
+
+		return mergePromise(process, promise)
+	}
+}

--- a/src/integrations/terminal/CLITerminalProcess.ts
+++ b/src/integrations/terminal/CLITerminalProcess.ts
@@ -1,0 +1,156 @@
+import { spawn, ChildProcess } from "child_process"
+import psTree from "ps-tree"
+import process from "process"
+
+import type { RooTerminal } from "./types"
+import { BaseTerminalProcess } from "./BaseTerminalProcess"
+
+/**
+ * CLI implementation of a terminal process using Node's child_process APIs.
+ * This mirrors the behaviour of VSCode's TerminalProcess but is suitable for
+ * running in a Node CLI environment.
+ */
+export class CLITerminalProcess extends BaseTerminalProcess {
+	private terminalRef: WeakRef<RooTerminal>
+	private subprocess?: ChildProcess
+	private pid?: number
+	private aborted = false
+
+	constructor(terminal: RooTerminal) {
+		super()
+		this.terminalRef = new WeakRef(terminal)
+		this.once("completed", () => {
+			this.terminal.busy = false
+		})
+	}
+
+	private get terminal(): RooTerminal {
+		const terminal = this.terminalRef.deref()
+		if (!terminal) {
+			throw new Error("Unable to dereference terminal")
+		}
+		return terminal
+	}
+
+	public override async run(command: string): Promise<void> {
+		this.command = command
+		this.isHot = true
+
+		this.subprocess = spawn(command, {
+			cwd: this.terminal.getCurrentWorkingDirectory(),
+			shell: true,
+			env: {
+				...process.env,
+				LANG: "en_US.UTF-8",
+				LC_ALL: "en_US.UTF-8",
+			},
+			stdio: ["ignore", "pipe", "pipe"],
+		})
+
+		this.pid = this.subprocess!.pid ?? undefined
+		this.terminal.running = true
+		this.emit("shell_execution_started", this.pid)
+
+		const onData = (chunk: Buffer) => {
+			if (this.aborted) {
+				return
+			}
+
+			const line = chunk.toString()
+			this.fullOutput += line
+			process.stdout.write(line)
+			const now = Date.now()
+			if (this.isListening && (now - this.lastEmitTime_ms > 500 || this.lastEmitTime_ms === 0)) {
+				this.emitRemainingBufferIfListening()
+				this.lastEmitTime_ms = now
+			}
+			this.startHotTimer(line)
+		}
+
+		this.subprocess.stdout?.on("data", onData)
+		this.subprocess.stderr?.on("data", onData)
+
+		const onSigint = () => {
+			this.aborted = true
+			try {
+				this.subprocess?.kill("SIGINT")
+			} catch (e) {}
+		}
+		process.once("SIGINT", onSigint)
+
+		await new Promise<void>((resolve) => {
+			this.subprocess?.once("close", (code, signal) => {
+				process.off("SIGINT", onSigint)
+				this.terminal.setActiveStream(undefined)
+				this.emitRemainingBufferIfListening()
+				this.stopHotTimer()
+				this.terminal.running = false
+				const exitDetails = { exitCode: code === null ? undefined : code, signalName: signal ?? undefined }
+				this.emit("shell_execution_complete", exitDetails)
+				this.emit("completed", this.fullOutput)
+				this.emit("continue")
+				resolve()
+			})
+			this.subprocess?.once("error", (err) => {
+				process.off("SIGINT", onSigint)
+				this.terminal.running = false
+				this.emit("error", err as Error)
+				resolve()
+			})
+		})
+
+		this.subprocess = undefined
+	}
+
+	public override continue(): void {
+		this.isListening = false
+		this.removeAllListeners("line")
+		this.emit("continue")
+	}
+
+	public override abort(): void {
+		this.aborted = true
+		if (this.subprocess) {
+			try {
+				this.subprocess.kill("SIGINT")
+			} catch (e) {}
+			if (this.pid) {
+				psTree(this.pid, (_err, children) => {
+					for (const child of children) {
+						const pid = parseInt(child.PID)
+						if (!isNaN(pid)) {
+							try {
+								process.kill(pid, "SIGKILL")
+							} catch (e) {}
+						}
+					}
+				})
+			}
+		}
+	}
+
+	public override hasUnretrievedOutput(): boolean {
+		return this.lastRetrievedIndex < this.fullOutput.length
+	}
+
+	public override getUnretrievedOutput(): string {
+		let output = this.fullOutput.slice(this.lastRetrievedIndex)
+		let index = output.lastIndexOf("\n")
+		if (index === -1) {
+			return ""
+		}
+		index++
+		this.lastRetrievedIndex += index
+		return output.slice(0, index)
+	}
+
+	private emitRemainingBufferIfListening(): void {
+		if (!this.isListening) {
+			return
+		}
+		const output = this.getUnretrievedOutput()
+		if (output !== "") {
+			this.emit("line", output)
+		}
+	}
+}

--- a/src/integrations/terminal/TerminalRegistry.ts
+++ b/src/integrations/terminal/TerminalRegistry.ts
@@ -6,6 +6,7 @@ import { RooTerminal, RooTerminalProvider } from "./types"
 import { TerminalProcess } from "./TerminalProcess"
 import { Terminal } from "./Terminal"
 import { ExecaTerminal } from "./ExecaTerminal"
+import { CLITerminal } from "./CLITerminal"
 import { ShellIntegrationManager } from "./ShellIntegrationManager"
 
 // Although vscode.window.terminals provides a list of all open terminals,
@@ -132,6 +133,8 @@ export class TerminalRegistry {
 
 		if (provider === "vscode") {
 			newTerminal = new Terminal(this.nextTerminalId++, undefined, cwd)
+		} else if (provider === "cli") {
+			newTerminal = new CLITerminal(this.nextTerminalId++, cwd)
 		} else {
 			newTerminal = new ExecaTerminal(this.nextTerminalId++, cwd)
 		}

--- a/src/integrations/terminal/types.ts
+++ b/src/integrations/terminal/types.ts
@@ -1,6 +1,6 @@
 import EventEmitter from "events"
 
-export type RooTerminalProvider = "vscode" | "execa"
+export type RooTerminalProvider = "vscode" | "execa" | "cli"
 
 export interface RooTerminal {
 	provider: RooTerminalProvider


### PR DESCRIPTION
## Summary
- add CLITerminal and process that run commands via Node's `child_process`, streaming output and handling SIGINT
- extend TerminalRegistry and types to recognize `cli` provider

## Testing
- `pnpm lint --filter="kilo-code"`
- `pnpm --filter=./src exec vitest run integrations/terminal/__tests__/TerminalRegistry.spec.ts`
- `pnpm check-types --filter=./src`


------
https://chatgpt.com/codex/tasks/task_e_68c5fa3a83088322a6329d898151e0c8